### PR TITLE
Add initial TypeORM migration support

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -57,6 +57,25 @@ $ pnpm run test:e2e
 $ pnpm run test:cov
 ```
 
+## Database migrations
+
+Use pnpm scripts to manage TypeORM migrations:
+
+```bash
+# generate a migration
+$ pnpm run migration:generate -- <name>
+
+# run pending migrations
+$ pnpm run migration:run
+
+# revert the last migration
+$ pnpm run migration:revert
+```
+
+Development follows a trunk-based workflow. Create feature branches from `main`
+and use [Conventional Commits](https://www.conventionalcommits.org/) for commit
+messages, e.g. `feat/migrations-initial-setup`.
+
 ## Deployment
 
 When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.

--- a/api/package.json
+++ b/api/package.json
@@ -18,7 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "migration:generate": "pnpm exec typeorm migration:generate src/migrations/<name> -d src/data-source.ts",
+    "migration:generate": "pnpm exec typeorm migration:generate -d dist/data-source.js",
     "migration:run": "pnpm exec typeorm migration:run -d dist/data-source.js",
     "migration:revert": "pnpm exec typeorm migration:revert -d dist/data-source.js"
   },

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,10 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "migration:generate": "pnpm exec typeorm migration:generate src/migrations/<name> -d src/data-source.ts",
+    "migration:run": "pnpm exec typeorm migration:run -d dist/data-source.js",
+    "migration:revert": "pnpm exec typeorm migration:revert -d dist/data-source.js"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
@@ -30,6 +33,7 @@
     "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",
     "@types/passport": "^1.0.17",
+    "dotenv": "^17.0.0",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.2.0",
     "nestjs-pino": "^4.4.0",

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@types/passport':
         specifier: ^1.0.17
         version: 1.0.17
+      dotenv:
+        specifier: ^17.0.0
+        version: 17.0.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -1845,6 +1848,10 @@ packages:
 
   dotenv@16.5.0:
     resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
+    engines: {node: '>=12'}
+
+  dotenv@17.0.0:
+    resolution: {integrity: sha512-A0BJ5lrpJVSfnMMXjmeO0xUnoxqsBHWCoqqTnGwGYVdnctqXXUEhJOO7LxmgxJon9tEZFGpe0xPRX0h2v3AANQ==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -5742,11 +5749,13 @@ snapshots:
 
   dotenv-expand@12.0.1:
     dependencies:
-      dotenv: 16.4.7
+      dotenv: 16.5.0
 
   dotenv@16.4.7: {}
 
   dotenv@16.5.0: {}
+
+  dotenv@17.0.0: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -4,6 +4,7 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common';
+import { CustomSnakeNamingStrategy } from './common/helpers';
 import { AppConfigModule } from './config/config.module';
 import { ConfigService } from './config/config.service';
 import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
@@ -33,7 +34,8 @@ import { AuthModule } from './auth/auth.module';
         password: cfg.dbPassword,
         database: cfg.dbName,
         entities: [__dirname + '/**/*.entity.{ts,js}'],
-        synchronize: cfg.nodeEnv === 'development',
+        namingStrategy: new CustomSnakeNamingStrategy(),
+        synchronize: false,
       }),
     }),
   ],

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -35,7 +35,7 @@ import { AuthModule } from './auth/auth.module';
         database: cfg.dbName,
         entities: [__dirname + '/**/*.entity.{ts,js}'],
         namingStrategy: new CustomSnakeNamingStrategy(),
-        synchronize: false,
+        synchronize: cfg.nodeEnv === 'development',
       }),
     }),
   ],

--- a/api/src/data-source.ts
+++ b/api/src/data-source.ts
@@ -1,6 +1,26 @@
 import 'dotenv/config';
-import { DataSource } from 'typeorm';
-import { CustomSnakeNamingStrategy } from './common/helpers';
+import { DataSource, DefaultNamingStrategy } from 'typeorm';
+
+class CustomSnakeNamingStrategy extends DefaultNamingStrategy {
+  tableName(className: string, customName: string): string {
+    return customName ? customName : this.camelToSnakeCase(className);
+  }
+
+  columnName(
+    propertyName: string,
+    customName: string,
+    _embeddedPrefixes: string[],
+  ): string {
+    return customName ? customName : this.camelToSnakeCase(propertyName);
+  }
+
+  private camelToSnakeCase(str: string): string {
+    return str
+      .replace(/([A-Z])/g, '_$1')
+      .toLowerCase()
+      .replace(/^_/, '');
+  }
+}
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
@@ -9,7 +29,8 @@ export const AppDataSource = new DataSource({
   username: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,
-  entities: ['dist/entities/*.js'],
+  entities: ['dist/entities/**/*.js'],
   migrations: ['dist/migrations/*.js'],
   namingStrategy: new CustomSnakeNamingStrategy(),
+  logger: 'advanced-console',
 });

--- a/api/src/entities/tenant.entity.ts
+++ b/api/src/entities/tenant.entity.ts
@@ -8,6 +8,12 @@ export class Tenant {
   @Column()
   name!: string;
 
+  @Column({ unique: true })
+  subdomain!: string;
+
+  @Column()
+  isDeleted: boolean = false;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 

--- a/api/src/entities/tenant.entity.ts
+++ b/api/src/entities/tenant.entity.ts
@@ -3,14 +3,14 @@ import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateCol
 @Entity()
 export class Tenant {
   @PrimaryGeneratedColumn('uuid')
-  id: string;
+  id!: string;
 
   @Column()
-  name: string;
+  name!: string;
 
   @CreateDateColumn({ name: 'created_at' })
-  createdAt: Date;
+  createdAt!: Date;
 
   @UpdateDateColumn({ name: 'updated_at' })
-  updatedAt: Date;
+  updatedAt!: Date;
 }

--- a/api/src/migrations/1751206537067-InitTenant.ts
+++ b/api/src/migrations/1751206537067-InitTenant.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class InitTenant1751206537067 implements MigrationInterface {
+    name = 'InitTenant1751206537067'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "tenant" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_da8c6efd67bb301e810e56ac139" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "tenant"`);
+    }
+
+}

--- a/api/src/migrations/1751206537067-InitTenant.ts
+++ b/api/src/migrations/1751206537067-InitTenant.ts
@@ -4,7 +4,7 @@ export class InitTenant1751206537067 implements MigrationInterface {
     name = 'InitTenant1751206537067'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "tenant" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_da8c6efd67bb301e810e56ac139" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "tenant" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "subdomain" character varying NOT NULL, "is_deleted" boolean NOT NULL DEFAULT false, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_tenant_subdomain" UNIQUE ("subdomain"), CONSTRAINT "PK_da8c6efd67bb301e810e56ac139" PRIMARY KEY ("id"))`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
## Summary
- configure migration scripts in `api/package.json`
- add initial migration for `Tenant`
- update TypeORM config to use snake case naming strategy
- document how to manage migrations

## Testing
- `pnpm run build`
- `pnpm exec typeorm migration:generate src/migrations/InitTenant -d dist/data-source.js`
- `pnpm run test` *(fails: Nest can't resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686149ba4a3c832e886e205c799207c3