### PR TITLE
feat(core): add base entity and interfaces

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -25,6 +25,14 @@
 
 [Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
 
+## Core Entities
+
+All data models live in `src/entities` and are paired with strict TypeScript
+interfaces in `src/common/interfaces`. Most models extend the shared
+`BaseEntity` found at `src/common/entities/BaseEntity.ts`, which provides
+`id`, `tenantId`, optional `companyId`, and timestamp columns. Every entity must
+implement its corresponding interface to keep typing strict across the project.
+
 ## Project setup
 
 ```bash
@@ -71,6 +79,16 @@ $ pnpm run migration:run
 # revert the last migration
 $ pnpm run migration:revert
 ```
+
+### Seeding initial roles
+
+After running migrations, seed the default system roles with:
+
+```bash
+$ pnpm run seed
+```
+
+Set `SEED_TENANT_ID` in your environment to associate the roles with a tenant.
 
 Development follows a trunk-based workflow. Create feature branches from `main`
 and use [Conventional Commits](https://www.conventionalcommits.org/) for commit

--- a/api/README.md
+++ b/api/README.md
@@ -29,9 +29,9 @@
 
 All data models live in `src/entities` and are paired with strict TypeScript
 interfaces in `src/common/interfaces`. Most models extend the shared
-`BaseEntity` found at `src/common/entities/BaseEntity.ts`, which provides
-`id`, `tenantId`, optional `companyId`, and timestamp columns. Every entity must
-implement its corresponding interface to keep typing strict across the project.
+`BaseEntity` found at `src/common/entities/BaseEntity.ts`, which provides an
+auto-generated `id` and timestamp columns. Every entity must implement its
+corresponding interface to keep typing strict across the project.
 
 ## Project setup
 

--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "migration:generate": "pnpm exec typeorm migration:generate -d dist/data-source.js",
     "migration:run": "pnpm exec typeorm migration:run -d dist/data-source.js",
-    "migration:revert": "pnpm exec typeorm migration:revert -d dist/data-source.js"
+    "migration:revert": "pnpm exec typeorm migration:revert -d dist/data-source.js",
+    "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/api/src/common/entities/BaseEntity.ts
+++ b/api/src/common/entities/BaseEntity.ts
@@ -1,6 +1,5 @@
 import {
   PrimaryGeneratedColumn,
-  Column,
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
@@ -8,12 +7,6 @@ import {
 export abstract class BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
-
-  @Column({ type: 'uuid' })
-  tenantId!: string;
-
-  @Column({ type: 'uuid', nullable: true })
-  companyId?: string | null;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;

--- a/api/src/common/entities/BaseEntity.ts
+++ b/api/src/common/entities/BaseEntity.ts
@@ -1,25 +1,19 @@
 import {
-  Entity,
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import { ITenant } from '../common/interfaces';
 
-@Entity()
-export class Tenant implements ITenant {
+export abstract class BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
-  @Column()
-  name!: string;
+  @Column({ type: 'uuid' })
+  tenantId!: string;
 
-  @Column({ unique: true })
-  subdomain!: string;
-
-  @Column({ default: false })
-  isDeleted: boolean = false;
+  @Column({ type: 'uuid', nullable: true })
+  companyId?: string | null;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;

--- a/api/src/common/interfaces/ICompany.ts
+++ b/api/src/common/interfaces/ICompany.ts
@@ -1,0 +1,8 @@
+export interface ICompany {
+  id: string;
+  tenantId: string;
+  companyId?: string | null;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/api/src/common/interfaces/ICompany.ts
+++ b/api/src/common/interfaces/ICompany.ts
@@ -1,8 +1,12 @@
 export interface ICompany {
   id: string;
   tenantId: string;
-  companyId?: string | null;
   name: string;
+  phone?: string | null;
+  address?: string | null;
+  contactEmail?: string | null;
+  isOwner: boolean;
+  isAdminUserCreated: boolean;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/api/src/common/interfaces/IDepartment.ts
+++ b/api/src/common/interfaces/IDepartment.ts
@@ -1,0 +1,8 @@
+export interface IDepartment {
+  id: string;
+  tenantId: string;
+  companyId?: string | null;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/api/src/common/interfaces/IDepartment.ts
+++ b/api/src/common/interfaces/IDepartment.ts
@@ -1,7 +1,6 @@
 export interface IDepartment {
   id: string;
-  tenantId: string;
-  companyId?: string | null;
+  companyId: string;
   name: string;
   createdAt: Date;
   updatedAt: Date;

--- a/api/src/common/interfaces/IRole.ts
+++ b/api/src/common/interfaces/IRole.ts
@@ -1,8 +1,10 @@
 export interface IRole {
   id: string;
   tenantId: string;
-  companyId?: string | null;
   name: string;
+  description?: string | null;
+  permissions?: unknown;
+  isSystemRole: boolean;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/api/src/common/interfaces/IRole.ts
+++ b/api/src/common/interfaces/IRole.ts
@@ -1,0 +1,8 @@
+export interface IRole {
+  id: string;
+  tenantId: string;
+  companyId?: string | null;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/api/src/common/interfaces/ITenant.ts
+++ b/api/src/common/interfaces/ITenant.ts
@@ -1,0 +1,8 @@
+export interface ITenant {
+  id: string;
+  name: string;
+  subdomain: string;
+  isDeleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/api/src/common/interfaces/ITenant.ts
+++ b/api/src/common/interfaces/ITenant.ts
@@ -1,8 +1,13 @@
+export enum TenantStatus {
+  Active = 'active',
+  Suspended = 'suspended',
+}
+
 export interface ITenant {
   id: string;
   name: string;
-  subdomain: string;
-  isDeleted: boolean;
+  subdomain?: string | null;
+  status: TenantStatus;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/api/src/common/interfaces/IUser.ts
+++ b/api/src/common/interfaces/IUser.ts
@@ -1,0 +1,13 @@
+import { IRole } from './IRole';
+
+export interface IUser {
+  id: string;
+  tenantId: string;
+  companyId?: string | null;
+  email: string;
+  firstName: string;
+  lastName: string;
+  roles?: IRole[];
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/api/src/common/interfaces/IUser.ts
+++ b/api/src/common/interfaces/IUser.ts
@@ -1,13 +1,19 @@
-import { IRole } from './IRole';
+export enum UserStatus {
+  Active = 'active',
+  Suspended = 'suspended',
+}
 
 export interface IUser {
   id: string;
   tenantId: string;
-  companyId?: string | null;
+  companyId: string;
+  departmentId: string;
   email: string;
-  firstName: string;
-  lastName: string;
-  roles?: IRole[];
+  fullName: string;
+  roleId: string;
+  status: UserStatus;
+  isDeleted: boolean;
+  auth0UserId: string;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/api/src/common/interfaces/index.ts
+++ b/api/src/common/interfaces/index.ts
@@ -1,0 +1,5 @@
+export * from './ITenant';
+export * from './ICompany';
+export * from './IDepartment';
+export * from './IRole';
+export * from './IUser';

--- a/api/src/entities/company.entity.ts
+++ b/api/src/entities/company.entity.ts
@@ -15,18 +15,18 @@ export class Company extends BaseEntity implements ICompany {
   @Column()
   name!: string;
 
-  @Column({ nullable: true })
+  @Column('varchar', { nullable: true })
   phone?: string | null;
 
-  @Column({ nullable: true })
+  @Column('varchar', { nullable: true })
   address?: string | null;
 
-  @Column({ name: 'contact_email', nullable: true })
+  @Column('varchar', { name: 'contact_email', nullable: true })
   contactEmail?: string | null;
 
-  @Column({ name: 'is_owner', default: false })
+  @Column('bool', { name: 'is_owner', default: false })
   isOwner = false;
 
-  @Column({ name: 'is_admin_user_created', default: false })
+  @Column('bool', { name: 'is_admin_user_created', default: false })
   isAdminUserCreated = false;
 }

--- a/api/src/entities/company.entity.ts
+++ b/api/src/entities/company.entity.ts
@@ -1,9 +1,32 @@
-import { Entity, Column } from 'typeorm';
+import { Entity, Column, Index } from 'typeorm';
 import { BaseEntity } from '../common/entities/BaseEntity';
 import { ICompany } from '../common/interfaces';
 
 @Entity()
+@Index(['tenantId', 'name'], { unique: true })
+@Index('UQ_company_owner_per_tenant', ['tenantId'], {
+  unique: true,
+  where: '"is_owner" = true',
+})
 export class Company extends BaseEntity implements ICompany {
+  @Column({ type: 'uuid' })
+  tenantId!: string;
+
   @Column()
   name!: string;
+
+  @Column({ nullable: true })
+  phone?: string | null;
+
+  @Column({ nullable: true })
+  address?: string | null;
+
+  @Column({ name: 'contact_email', nullable: true })
+  contactEmail?: string | null;
+
+  @Column({ name: 'is_owner', default: false })
+  isOwner = false;
+
+  @Column({ name: 'is_admin_user_created', default: false })
+  isAdminUserCreated = false;
 }

--- a/api/src/entities/company.entity.ts
+++ b/api/src/entities/company.entity.ts
@@ -1,0 +1,9 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from '../common/entities/BaseEntity';
+import { ICompany } from '../common/interfaces';
+
+@Entity()
+export class Company extends BaseEntity implements ICompany {
+  @Column()
+  name!: string;
+}

--- a/api/src/entities/department.entity.ts
+++ b/api/src/entities/department.entity.ts
@@ -1,9 +1,13 @@
-import { Entity, Column } from 'typeorm';
+import { Entity, Column, Index } from 'typeorm';
 import { BaseEntity } from '../common/entities/BaseEntity';
 import { IDepartment } from '../common/interfaces';
 
 @Entity()
+@Index(['companyId', 'name'], { unique: true })
 export class Department extends BaseEntity implements IDepartment {
+  @Column({ type: 'uuid' })
+  companyId!: string;
+
   @Column()
   name!: string;
 }

--- a/api/src/entities/department.entity.ts
+++ b/api/src/entities/department.entity.ts
@@ -1,0 +1,9 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from '../common/entities/BaseEntity';
+import { IDepartment } from '../common/interfaces';
+
+@Entity()
+export class Department extends BaseEntity implements IDepartment {
+  @Column()
+  name!: string;
+}

--- a/api/src/entities/index.ts
+++ b/api/src/entities/index.ts
@@ -1,0 +1,5 @@
+export * from './tenant.entity';
+export * from './company.entity';
+export * from './department.entity';
+export * from './role.entity';
+export * from './user.entity';

--- a/api/src/entities/role.entity.ts
+++ b/api/src/entities/role.entity.ts
@@ -11,12 +11,12 @@ export class Role extends BaseEntity implements IRole {
   @Column()
   name!: string;
 
-  @Column({ nullable: true })
-  description?: string | null;
+  @Column('varchar', { nullable: true })
+  description!: string | null;
 
   @Column('jsonb', { nullable: true })
-  permissions?: unknown;
+  permissions!: unknown;
 
-  @Column({ name: 'is_system_role', default: false })
+  @Column('bool', { name: 'is_system_role', default: false })
   isSystemRole = false;
 }

--- a/api/src/entities/role.entity.ts
+++ b/api/src/entities/role.entity.ts
@@ -1,0 +1,9 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from '../common/entities/BaseEntity';
+import { IRole } from '../common/interfaces';
+
+@Entity()
+export class Role extends BaseEntity implements IRole {
+  @Column({ unique: true })
+  name!: string;
+}

--- a/api/src/entities/role.entity.ts
+++ b/api/src/entities/role.entity.ts
@@ -1,9 +1,22 @@
-import { Entity, Column } from 'typeorm';
+import { Entity, Column, Index } from 'typeorm';
 import { BaseEntity } from '../common/entities/BaseEntity';
 import { IRole } from '../common/interfaces';
 
 @Entity()
+@Index(['tenantId', 'name'], { unique: true })
 export class Role extends BaseEntity implements IRole {
-  @Column({ unique: true })
+  @Column({ type: 'uuid' })
+  tenantId!: string;
+
+  @Column()
   name!: string;
+
+  @Column({ nullable: true })
+  description?: string | null;
+
+  @Column('jsonb', { nullable: true })
+  permissions?: unknown;
+
+  @Column({ name: 'is_system_role', default: false })
+  isSystemRole = false;
 }

--- a/api/src/entities/tenant.entity.ts
+++ b/api/src/entities/tenant.entity.ts
@@ -17,9 +17,9 @@ export class Tenant implements ITenant {
   @Index({ unique: true })
   name!: string;
 
-  @Column({ nullable: true })
+  @Column('varchar', { nullable: true })
   @Index({ unique: true })
-  subdomain?: string | null;
+  subdomain!: string | null;
 
   @Column({ type: 'enum', enum: TenantStatus, default: TenantStatus.Active })
   status!: TenantStatus;

--- a/api/src/entities/tenant.entity.ts
+++ b/api/src/entities/tenant.entity.ts
@@ -4,8 +4,9 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  Index,
 } from 'typeorm';
-import { ITenant } from '../common/interfaces';
+import { ITenant, TenantStatus } from '../common/interfaces';
 
 @Entity()
 export class Tenant implements ITenant {
@@ -13,13 +14,15 @@ export class Tenant implements ITenant {
   id!: string;
 
   @Column()
+  @Index({ unique: true })
   name!: string;
 
-  @Column({ unique: true })
-  subdomain!: string;
+  @Column({ nullable: true })
+  @Index({ unique: true })
+  subdomain?: string | null;
 
-  @Column({ default: false })
-  isDeleted: boolean = false;
+  @Column({ type: 'enum', enum: TenantStatus, default: TenantStatus.Active })
+  status!: TenantStatus;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;

--- a/api/src/entities/user.entity.ts
+++ b/api/src/entities/user.entity.ts
@@ -1,20 +1,34 @@
-import { Entity, Column, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, Column, Index } from 'typeorm';
 import { BaseEntity } from '../common/entities/BaseEntity';
-import { IUser, IRole } from '../common/interfaces';
-import { Role } from './role.entity';
+import { IUser, UserStatus } from '../common/interfaces';
 
 @Entity()
+@Index('UQ_user_email', ['email'], { unique: true })
 export class User extends BaseEntity implements IUser {
-  @Column({ unique: true })
+  @Column({ type: 'uuid' })
+  tenantId!: string;
+
+  @Column({ type: 'uuid' })
+  companyId!: string;
+
+  @Column({ type: 'uuid' })
+  departmentId!: string;
+
+  @Column()
   email!: string;
 
-  @Column()
-  firstName!: string;
+  @Column({ name: 'full_name' })
+  fullName!: string;
 
-  @Column()
-  lastName!: string;
+  @Column({ type: 'uuid', name: 'role_id' })
+  roleId!: string;
 
-  @ManyToMany(() => Role)
-  @JoinTable({ name: 'user_roles' })
-  roles?: IRole[];
+  @Column({ type: 'enum', enum: UserStatus, default: UserStatus.Active })
+  status!: UserStatus;
+
+  @Column({ name: 'is_deleted', default: false })
+  isDeleted = false;
+
+  @Column({ name: 'auth0_user_id' })
+  auth0UserId!: string;
 }

--- a/api/src/entities/user.entity.ts
+++ b/api/src/entities/user.entity.ts
@@ -26,7 +26,7 @@ export class User extends BaseEntity implements IUser {
   @Column({ type: 'enum', enum: UserStatus, default: UserStatus.Active })
   status!: UserStatus;
 
-  @Column({ name: 'is_deleted', default: false })
+  @Column('bool', { name: 'is_deleted', default: false })
   isDeleted = false;
 
   @Column({ name: 'auth0_user_id' })

--- a/api/src/entities/user.entity.ts
+++ b/api/src/entities/user.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, Column, ManyToMany, JoinTable } from 'typeorm';
+import { BaseEntity } from '../common/entities/BaseEntity';
+import { IUser, IRole } from '../common/interfaces';
+import { Role } from './role.entity';
+
+@Entity()
+export class User extends BaseEntity implements IUser {
+  @Column({ unique: true })
+  email!: string;
+
+  @Column()
+  firstName!: string;
+
+  @Column()
+  lastName!: string;
+
+  @ManyToMany(() => Role)
+  @JoinTable({ name: 'user_roles' })
+  roles?: IRole[];
+}

--- a/api/src/migrations/1751226968-InitCoreEntities.ts
+++ b/api/src/migrations/1751226968-InitCoreEntities.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class InitCoreEntities1751226968 implements MigrationInterface {
+  name = 'InitCoreEntities1751226968';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "company" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "tenant_id" uuid NOT NULL, "company_id" uuid, "name" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_4fab8d0e1d3cdad0c158b1f3c5a" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "department" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "tenant_id" uuid NOT NULL, "company_id" uuid, "name" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_48d3a2e8b0a21d16b3f9f1fe8fe" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "role" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "tenant_id" uuid NOT NULL, "company_id" uuid, "name" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_role_name" UNIQUE ("name"), CONSTRAINT "PK_34eb6057072f734bf38ba730390" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "tenant_id" uuid NOT NULL, "company_id" uuid, "email" character varying NOT NULL, "first_name" character varying NOT NULL, "last_name" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_user_email" UNIQUE ("email"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_roles" ("user_id" uuid NOT NULL, "role_id" uuid NOT NULL, CONSTRAINT "PK_user_roles" PRIMARY KEY ("user_id", "role_id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_roles" ADD CONSTRAINT "FK_user_roles_user" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_roles" ADD CONSTRAINT "FK_user_roles_role" FOREIGN KEY ("role_id") REFERENCES "role"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_roles" DROP CONSTRAINT "FK_user_roles_role"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_roles" DROP CONSTRAINT "FK_user_roles_user"`,
+    );
+    await queryRunner.query(`DROP TABLE "user_roles"`);
+    await queryRunner.query(`DROP TABLE "user"`);
+    await queryRunner.query(`DROP TABLE "role"`);
+    await queryRunner.query(`DROP TABLE "department"`);
+    await queryRunner.query(`DROP TABLE "company"`);
+  }
+}

--- a/api/src/migrations/1751226968000-InitCoreEntities.ts
+++ b/api/src/migrations/1751226968000-InitCoreEntities.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class InitCoreEntities1751226968 implements MigrationInterface {
-  name = 'InitCoreEntities1751226968';
+export class InitCoreEntities1751226968000 implements MigrationInterface {
+  name = 'InitCoreEntities1751226968000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/api/src/migrations/1751233944851-UpdateCoreEntities.ts
+++ b/api/src/migrations/1751233944851-UpdateCoreEntities.ts
@@ -1,0 +1,154 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateCoreEntities1751233944851 implements MigrationInterface {
+  name = 'UpdateCoreEntities1751233944851';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // tenant adjustments
+    await queryRunner.query(
+      `ALTER TABLE "tenant" ADD "status" character varying NOT NULL DEFAULT 'active'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tenant" ALTER COLUMN "subdomain" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tenant" ADD CONSTRAINT "UQ_tenant_name" UNIQUE ("name")`,
+    );
+    await queryRunner.query(`ALTER TABLE "tenant" DROP COLUMN "is_deleted"`);
+
+    // company adjustments
+    await queryRunner.query(`ALTER TABLE "company" DROP COLUMN "company_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "company" ADD "phone" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "company" ADD "address" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "company" ADD "contact_email" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "company" ADD "is_owner" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "company" ADD "is_admin_user_created" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_company_tenant_name" ON "company" ("tenant_id", "name")`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_company_owner" ON "company" ("tenant_id") WHERE is_owner = true`,
+    );
+
+    // department adjustments
+    await queryRunner.query(`ALTER TABLE "department" DROP COLUMN "tenant_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "department" ALTER COLUMN "company_id" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_department_company_name" ON "department" ("company_id", "name")`,
+    );
+
+    // role adjustments
+    await queryRunner.query(
+      `ALTER TABLE "role" DROP CONSTRAINT "UQ_role_name"`,
+    );
+    await queryRunner.query(`ALTER TABLE "role" DROP COLUMN "company_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "role" ADD "description" character varying`,
+    );
+    await queryRunner.query(`ALTER TABLE "role" ADD "permissions" jsonb`);
+    await queryRunner.query(
+      `ALTER TABLE "role" ADD "is_system_role" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_role_tenant_name" ON "role" ("tenant_id", "name")`,
+    );
+
+    // user adjustments
+    await queryRunner.query(`DROP TABLE "user_roles"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "first_name"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "last_name"`);
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "department_id" uuid NOT NULL`,
+    );
+    await queryRunner.query(`ALTER TABLE "user" ADD "role_id" uuid NOT NULL`);
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "full_name" character varying NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "status" character varying NOT NULL DEFAULT 'active'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "is_deleted" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "auth0_user_id" character varying NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "company_id" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_user_email" ON "user" ("email")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_user_email"`);
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "company_id" DROP NOT NULL`,
+    );
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "auth0_user_id"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "is_deleted"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "status"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "full_name"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "role_id"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "department_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "last_name" character varying NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "first_name" character varying NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_roles" ("user_id" uuid NOT NULL, "role_id" uuid NOT NULL, CONSTRAINT "PK_user_roles" PRIMARY KEY ("user_id", "role_id"))`,
+    );
+    await queryRunner.query(`DROP INDEX "IDX_role_tenant_name"`);
+    await queryRunner.query(`ALTER TABLE "role" DROP COLUMN "is_system_role"`);
+    await queryRunner.query(`ALTER TABLE "role" DROP COLUMN "permissions"`);
+    await queryRunner.query(`ALTER TABLE "role" DROP COLUMN "description"`);
+    await queryRunner.query(`ALTER TABLE "role" ADD "company_id" uuid`);
+    await queryRunner.query(
+      `ALTER TABLE "role" ADD CONSTRAINT "UQ_role_name" UNIQUE ("name")`,
+    );
+    await queryRunner.query(`DROP INDEX "IDX_department_company_name"`);
+    await queryRunner.query(
+      `ALTER TABLE "department" ALTER COLUMN "company_id" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "department" ADD "tenant_id" uuid NOT NULL`,
+    );
+    await queryRunner.query(`DROP INDEX "IDX_company_owner"`);
+    await queryRunner.query(`DROP INDEX "IDX_company_tenant_name"`);
+    await queryRunner.query(
+      `ALTER TABLE "company" DROP COLUMN "is_admin_user_created"`,
+    );
+    await queryRunner.query(`ALTER TABLE "company" DROP COLUMN "is_owner"`);
+    await queryRunner.query(
+      `ALTER TABLE "company" DROP COLUMN "contact_email"`,
+    );
+    await queryRunner.query(`ALTER TABLE "company" DROP COLUMN "address"`);
+    await queryRunner.query(`ALTER TABLE "company" DROP COLUMN "phone"`);
+    await queryRunner.query(`ALTER TABLE "company" ADD "company_id" uuid`);
+    await queryRunner.query(
+      `ALTER TABLE "tenant" ADD "is_deleted" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tenant" DROP CONSTRAINT "UQ_tenant_name"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tenant" ALTER COLUMN "subdomain" SET NOT NULL`,
+    );
+    await queryRunner.query(`ALTER TABLE "tenant" DROP COLUMN "status"`);
+  }
+}

--- a/api/src/migrations/1751233944851-UpdateCoreEntities.ts
+++ b/api/src/migrations/1751233944851-UpdateCoreEntities.ts
@@ -91,9 +91,41 @@ export class UpdateCoreEntities1751233944851 implements MigrationInterface {
     await queryRunner.query(
       `CREATE UNIQUE INDEX "IDX_user_email" ON "user" ("email")`,
     );
+
+    // foreign keys
+    await queryRunner.query(
+      `ALTER TABLE "company" ADD CONSTRAINT "FK_company_tenant" FOREIGN KEY ("tenant_id") REFERENCES "tenant"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "department" ADD CONSTRAINT "FK_department_company" FOREIGN KEY ("company_id") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "role" ADD CONSTRAINT "FK_role_tenant" FOREIGN KEY ("tenant_id") REFERENCES "tenant"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "FK_user_tenant" FOREIGN KEY ("tenant_id") REFERENCES "tenant"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "FK_user_company" FOREIGN KEY ("company_id") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "FK_user_department" FOREIGN KEY ("department_id") REFERENCES "department"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "FK_user_role" FOREIGN KEY ("role_id") REFERENCES "role"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    // drop foreign keys
+    await queryRunner.query(`ALTER TABLE "user" DROP CONSTRAINT "FK_user_role"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP CONSTRAINT "FK_user_department"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP CONSTRAINT "FK_user_company"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP CONSTRAINT "FK_user_tenant"`);
+    await queryRunner.query(`ALTER TABLE "role" DROP CONSTRAINT "FK_role_tenant"`);
+    await queryRunner.query(`ALTER TABLE "department" DROP CONSTRAINT "FK_department_company"`);
+    await queryRunner.query(`ALTER TABLE "company" DROP CONSTRAINT "FK_company_tenant"`);
+
     await queryRunner.query(`DROP INDEX "IDX_user_email"`);
     await queryRunner.query(
       `ALTER TABLE "user" ALTER COLUMN "company_id" DROP NOT NULL`,

--- a/api/src/seed.ts
+++ b/api/src/seed.ts
@@ -1,0 +1,22 @@
+import { AppDataSource } from './data-source';
+import { Role } from './entities/role.entity';
+
+async function seed(): Promise<void> {
+  await AppDataSource.initialize();
+  const repo = AppDataSource.getRepository(Role);
+  const tenantId =
+    process.env.SEED_TENANT_ID ?? '00000000-0000-0000-0000-000000000000';
+  const roles = ['admin', 'user', 'auditor', 'super-user'];
+  for (const name of roles) {
+    const exists = await repo.findOne({ where: { name } });
+    if (!exists) {
+      await repo.save(repo.create({ name, tenantId }));
+    }
+  }
+  await AppDataSource.destroy();
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/api/src/seed.ts
+++ b/api/src/seed.ts
@@ -10,7 +10,7 @@ async function seed(): Promise<void> {
   for (const name of roles) {
     const exists = await repo.findOne({ where: { name } });
     if (!exists) {
-      await repo.save(repo.create({ name, tenantId }));
+      await repo.save(repo.create({ name, tenantId, isSystemRole: true }));
     }
   }
   await AppDataSource.destroy();


### PR DESCRIPTION
## Summary
- add `BaseEntity` abstract class for shared columns
- define interfaces for Tenant, Company, Department, Role and User
- implement core entities extending `BaseEntity`
- expose interface exports
- add migration and role seeding script
- document usage of entities, interfaces and seeding

## Testing
- `pnpm lint` *(fails: Unsafe construction of error types)*
- `pnpm test` *(fails: Nest can't resolve dependencies)*
- `pnpm run migration:run` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6861995b64a0832eb03cf2e1d9ba9b60